### PR TITLE
Audio response recording indicator options

### DIFF
--- a/plugins/jspsych-image-audio-response.js
+++ b/plugins/jspsych-image-audio-response.js
@@ -78,27 +78,27 @@ jsPsych.plugins["image-audio-response"] = (function() {
                 description: 'Whether to allow the participant to play back their '+
                 'recording and re-record if unhappy.'
             },
-			recording_indicator: {
-				type: jsPsych.plugins.parameterType.INT,
-				pretty_name: 'Recording indicator type',
-				default: 1,
-				description: 'Selects which recording indicator type to use. '+
-				'1- Obvious recording indicator (default). '+
-				'2- Unobtrusive recording indicator. '+
-				'3- Custom HTML. Stimulus will be placed directly above the HTML. '+
-				'4- Custom HTML. Stimulus will centred regardless of HTML positioning. '
-			},
+            recording_indicator: {
+                type: jsPsych.plugins.parameterType.INT,
+                pretty_name: 'Recording indicator type',
+                default: 1,
+                description: 'Selects which recording indicator type to use. '+
+                '1- Obvious recording indicator (default). '+
+                '2- Unobtrusive recording indicator. '+
+                '3- Custom HTML. Stimulus will be placed directly above the HTML. '+
+                '4- Custom HTML. Stimulus will centred regardless of HTML positioning. '
+            },
             recording_on_indicator: {
                 type: jsPsych.plugins.parameterType.HTML_STRING,
                 pretty_name: 'Recording indicator (on state)',
-				default: null, // default behaviour specified line 201
-				description: 'HTML to display while recording is in progress.'
+                default: null, // default behaviour specified line 201
+                description: 'HTML to display while recording is in progress.'
             },
             recording_off_indicator: {
                 type: jsPsych.plugins.parameterType.HTML_STRING,
                 pretty_name: 'Recording indicator (off state)',
-					default: null, // default behaviour specified line 201
-				description: 'HTML to display while recording is not in progress.'
+                default: null, // default behaviour specified line 201
+                description: 'HTML to display while recording is not in progress.'
             },
             prompt: {
                 type: jsPsych.plugins.parameterType.STRING,
@@ -112,24 +112,24 @@ jsPsych.plugins["image-audio-response"] = (function() {
                 default: null,
                 description: 'How long to show the stimulus.'
             },
-			stimulus_height: {
-				type: jsPsych.plugins.parameterType.INT,
-				pretty_name: 'Image height',
-				default: null,
-				description: 'Set the image height in pixels'
-			},
-			stimulus_width: {
-				type: jsPsych.plugins.parameterType.INT,
-				pretty_name: 'Image width',
-				default: null,
-				description: 'Set the image width in pixels'
-			},
-			maintain_aspect_ratio: {
-				type: jsPsych.plugins.parameterType.BOOL,
-				pretty_name: 'Maintain aspect ratio',
-				default: true,
-				description: 'Maintain the aspect ratio after setting width or height'
-			},
+            stimulus_height: {
+                type: jsPsych.plugins.parameterType.INT,
+                pretty_name: 'Image height',
+                default: null,
+                description: 'Set the image height in pixels'
+            },
+            stimulus_width: {
+                type: jsPsych.plugins.parameterType.INT,
+                pretty_name: 'Image width',
+                default: null,
+                description: 'Set the image width in pixels'
+            },
+            maintain_aspect_ratio: {
+                type: jsPsych.plugins.parameterType.BOOL,
+                pretty_name: 'Maintain aspect ratio',
+                default: true,
+                description: 'Maintain the aspect ratio after setting width or height'
+            },
             margin_vertical: {
                 type: jsPsych.plugins.parameterType.STRING,
                 pretty_name: 'Margin vertical',
@@ -153,6 +153,18 @@ jsPsych.plugins["image-audio-response"] = (function() {
                 pretty_name: 'Wait for mic approval',
                 default: false,
                 description: 'If true, the trial will not start until the participant approves the browser mic request.'
+            },
+            no_mic_message: {
+                type: jsPsych.plugins.parameterType.HTML_STRING,
+                pretty_name: 'No mic message',
+                default: 'Audio recording not possible.',
+                description: 'Message to show if no mic is found, or if the browser is not compatible.'
+            }, 
+            no_mic_message_duration: {
+                type: jsPsych.plugins.parameterType.INT,
+                pretty_name: 'No mic message duration',
+                default: 3000,
+                description: 'Duration to show the no mic message, if no mic is found or the browser is not compatible.'
             }
         }
     };
@@ -171,196 +183,234 @@ jsPsych.plugins["image-audio-response"] = (function() {
         };
         let recorder = null;
         let start_time = null;
+        var mic = false;
 
-        // add stimulus
-		var html = '<img src="'+trial.stimulus+'" id="jspsych-image-audio-response-stimulus"';
-		if (trial.recording_indicator === 1 || trial.recording_indicator === 3) {
-			// if recording indicator is type 1 or 3 , then do nothing
-			// stimulus will stack on audio recording containers
-			html += 'style="';
-		} else {
-			// else dynamically position stimulus in centre of screen
-			// stimulus will be positioned out of flow
-			html += 'style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);';
-		}
-		if(trial.stimulus_height !== null){
-		  html += 'height:'+trial.stimulus_height+'px;';
-		  if(trial.stimulus_width == null && trial.maintain_aspect_ratio){
-			html += 'width: auto; ';
-		  }
-		}
-		if(trial.stimulus_width !== null){
-		  html += 'width:'+trial.stimulus_width+'px; '
-		  if(trial.stimulus_height == null && trial.maintain_aspect_ratio){
-			html += 'height: auto; ';
-		  }
-		}
-		html +='"></img>';
-
-        // add prompt if there is one
-        if (trial.prompt !== null) {
-            html += trial.prompt;
-        }
-		
-		// set up recording indicator
-		if (trial.recording_indicator === 1) {
-			// if indicator type 1, do HTML for obvious indicator
-			trial.recording_on_indicator = '<div id="jspsych-image-audio-response-indicator" '+
-				'style="border: 2px solid darkred; background-color: darkred; '+
-				'width: 50px; height: 50px; border-radius: 50px; margin: 20px auto; '+
-				'display: block;"></div>';	
-			trial.recording_off_indicator = '<div id="jspsych-image-audio-response-indicator" '+
-				'style="border: 2px solid darkred; background-color: inherit; '+
-				'width: 50px; height: 50px; border-radius: 50px; margin: 20px auto; '+
-				'display: block;"></div>';	
-		} else if (trial.recording_indicator === 2) {
-			// if indicator type 2 do HTML for unobtrusive indicator
-			trial.recording_on_indicator = '<div id="jspsych-image-audio-response-indicator" '+
-				'style="position: fixed; bottom: 0; right: 0;">recording...</div>';	
-			trial.recording_off_indicator = '<div id="jspsych-image-audio-response-indicator" '+
-				'style="position: fixed; bottom: 0; right: 0;">not recording...</div>';	
-		} else {
-			// if any other indicator type && HTML left unspecified then throw error but continue
-			if (trial.recording_on_indicator === null || trial.recording_off_indicator === null) {
-				console.error('No recording indicator HTML specified.');
-			}	
-		} 
-
-        // add recording off indicator into HTML
-        html += '<div id="jspsych-image-audio-response-recording-container">'+trial.recording_off_indicator+'</div>';
-
-        // add audio element container with hidden audio element
-        html += '<div id="jspsych-image-audio-response-audio-container"><audio id="jspsych-image-audio-response-audio" controls style="visibility:hidden;"></audio></div>';
-
-        // add button element with hidden buttons
-        html += '<div id="jspsych-image-audio-response-buttons"><button id="jspsych-image-audio-response-okay" class="jspsych-audio-response-button jspsych-btn" style="display: inline-block; margin:'+trial.margin_vertical+' '+trial.margin_horizontal+'; visibility:hidden;">Okay</button><button id="jspsych-image-audio-response-rerecord" class="jspsych-audio-response-button jspsych-btn" style="display: inline-block; margin:'+trial.margin_vertical+' '+trial.margin_horizontal+'; visibility:hidden;">Rerecord</button></div>';
-
-        function start_trial() {
-            display_element.innerHTML = html;
-            document.querySelector('#jspsych-image-audio-response-okay').addEventListener('click', end_trial);
-            document.querySelector('#jspsych-image-audio-response-rerecord').addEventListener('click', start_recording);
-            // Add visual indicators to let people know we're recording
-            document.querySelector('#jspsych-image-audio-response-recording-container').innerHTML = trial.recording_on_indicator;
-            // trial start time
-            start_time = performance.now();
-            // set timer to hide image if stimulus duration is set
-            if (trial.stimulus_duration !== null) {
-                jsPsych.pluginAPI.setTimeout(function() {
-                    display_element.querySelector('#jspsych-image-audio-response-stimulus').style.visibility = 'hidden';
-                }, trial.stimulus_duration);
+        // check if device has a mic, and if browser is compatible
+        // from https://stackoverflow.com/questions/23288918/check-if-user-has-webcam-or-not-using-javascript-only/23289012
+        function detect_mic(callback) {
+            let md = navigator.mediaDevices;
+            if (!md || !md.enumerateDevices || !md.getUserMedia) {
+                callback(false);
             }
-            if (!trial.wait_for_mic_approval) {
-                start_recording();
-            }
-        }
-
-        // audio element processing
-        function start_recording() {
-            // hide existing playback elements
-            playbackElements.forEach(function (id) {
-                let element = document.getElementById(id);
-                element.style.visibility = 'hidden';
+            md.enumerateDevices().then(function(devices) {
+                var hasmic = devices.some(function(device) {
+                    return 'audioinput' === device.kind;
+                });
+                callback(hasmic);
             });
-            navigator.mediaDevices.getUserMedia({ audio: true, video: false }).then(process_audio);
-            if (!trial.wait_for_mic_approval) {
-                // Add visual indicators to let people know we're recording
-                document.querySelector('#jspsych-image-audio-response-recording-container').innerHTML = trial.recording_on_indicator;
-            }
         }
-        
-        // function to handle responses by the subject
-        function process_audio(stream) {
 
-            if (trial.wait_for_mic_approval) {
-                if (start_time === null) {
-                    start_trial();
+        detect_mic(function(has_mic) {
+
+            if (!has_mic) {
+
+                // no mic, or browser is not compatible, so display a message and then end the trial
+                display_element.innerHTML = trial.no_mic_message;
+                jsPsych.pluginAPI.setTimeout(function() {
+                    end_trial();
+                }, trial.no_mic_message_duration);
+
+            } else {
+
+                mic = true;
+
+                // add stimulus
+                var html = '<img src="'+trial.stimulus+'" id="jspsych-image-audio-response-stimulus"';
+                if (trial.recording_indicator === 1 || trial.recording_indicator === 3) {
+                    // if recording indicator is type 1 or 3 , then do nothing
+                    // stimulus will stack on audio recording containers
+                    html += 'style="';
                 } else {
-                    document.querySelector('#jspsych-image-audio-response-recording-container').innerHTML = trial.recording_on_indicator;
+                    // else dynamically position stimulus in centre of screen
+                    // stimulus will be positioned out of flow
+                    html += 'style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);';
                 }
-            } 
-
-            // This code largely thanks to skyllo at
-            // http://air.ghost.io/recording-to-an-audio-file-using-html5-and-js/
-
-            // store streaming data chunks in array
-            const chunks = [];
-            // create media recorder instance to initialize recording
-            // Note: the MediaRecorder function is not supported in Safari or Edge
-            recorder = new MediaRecorder(stream);
-            recorder.data = [];
-            recorder.wrapUp = false;
-            recorder.ondataavailable = function(e) {
-                // add stream data to chunks
-                chunks.push(e.data);
-                if (recorder.wrapUp) {
-                    if (typeof trial.postprocessing !== 'undefined') {
-                        trial.postprocessing(chunks)
-                            .then(function(processedData) {
-                                onRecordingFinish(processedData);
-                            });
-                    } else {
-                        // should never fire - trial.postprocessing should use the default function if
-                        // not passed in via trial parameters
-                        onRecordingFinish(chunks);
+                if(trial.stimulus_height !== null){
+                    html += 'height:'+trial.stimulus_height+'px;';
+                    if(trial.stimulus_width == null && trial.maintain_aspect_ratio){
+                        html += 'width: auto; ';
                     }
                 }
-            };
+                if(trial.stimulus_width !== null){
+                    html += 'width:'+trial.stimulus_width+'px; '
+                    if(trial.stimulus_height == null && trial.maintain_aspect_ratio){
+                        html += 'height: auto; ';
+                    }
+                }
+                html +='"></img>';
 
-            // start recording with 1 second time between receiving 'ondataavailable' events
-            recorder.start(1000);
-            // setTimeout to stop recording after 4 seconds
-            setTimeout(function() {
-                // this will trigger one final 'ondataavailable' event and set recorder state to 'inactive'
-                recorder.stop();
-                recorder.wrapUp = true;
-            }, trial.buffer_length);
-        }
+                // add prompt if there is one
+                if (trial.prompt !== null) {
+                    html += trial.prompt;
+                }
 
-        function showPlaybackTools(data) {
-            // Audio Player
-            let playerDiv = display_element.querySelector('#jspsych-image-audio-response-audio-container');
-            let url;
-            if (data instanceof Blob) {
-                const blob = new Blob(data, { type: 'audio/webm' });
-                url = (URL.createObjectURL(blob));
-            } else {
-                url = data;
+                // set up recording indicator
+                if (trial.recording_indicator === 1) {
+                    // if indicator type 1, do HTML for obvious indicator
+                    trial.recording_on_indicator = '<div id="jspsych-image-audio-response-indicator" '+
+                        'style="border: 2px solid darkred; background-color: darkred; '+
+                        'width: 50px; height: 50px; border-radius: 50px; margin: 20px auto; '+
+                        'display: block;"></div>';	
+                    trial.recording_off_indicator = '<div id="jspsych-image-audio-response-indicator" '+
+                        'style="border: 2px solid darkred; background-color: inherit; '+
+                        'width: 50px; height: 50px; border-radius: 50px; margin: 20px auto; '+
+                        'display: block;"></div>';	
+                } else if (trial.recording_indicator === 2) {
+                    // if indicator type 2 do HTML for unobtrusive indicator
+                    trial.recording_on_indicator = '<div id="jspsych-image-audio-response-indicator" '+
+                        'style="position: fixed; bottom: 0; right: 0;">recording...</div>';	
+                    trial.recording_off_indicator = '<div id="jspsych-image-audio-response-indicator" '+
+                        'style="position: fixed; bottom: 0; right: 0;">not recording...</div>';	
+                } else {
+                    // if any other indicator type && HTML left unspecified then throw error but continue
+                    if (trial.recording_on_indicator === null || trial.recording_off_indicator === null) {
+                        console.error('No recording indicator HTML specified.');
+                    }	
+                } 
+
+                // add recording off indicator into HTML
+                html += '<div id="jspsych-image-audio-response-recording-container">'+trial.recording_off_indicator+'</div>';
+
+                // add audio element container with hidden audio element
+                html += '<div id="jspsych-image-audio-response-audio-container"><audio id="jspsych-image-audio-response-audio" controls style="visibility:hidden;"></audio></div>';
+
+                // add button element with hidden buttons
+                html += '<div id="jspsych-image-audio-response-buttons"><button id="jspsych-image-audio-response-okay" class="jspsych-audio-response-button jspsych-btn" style="display: inline-block; margin:'+trial.margin_vertical+' '+trial.margin_horizontal+'; visibility:hidden;">Okay</button><button id="jspsych-image-audio-response-rerecord" class="jspsych-audio-response-button jspsych-btn" style="display: inline-block; margin:'+trial.margin_vertical+' '+trial.margin_horizontal+'; visibility:hidden;">Rerecord</button></div>';
+
+                function start_trial() {
+                    display_element.innerHTML = html;
+                    document.querySelector('#jspsych-image-audio-response-okay').addEventListener('click', end_trial);
+                    document.querySelector('#jspsych-image-audio-response-rerecord').addEventListener('click', start_recording);
+                    // Add visual indicators to let people know we're recording
+                    document.querySelector('#jspsych-image-audio-response-recording-container').innerHTML = trial.recording_on_indicator;
+                    // trial start time
+                    start_time = performance.now();
+                    // set timer to hide image if stimulus duration is set
+                    if (trial.stimulus_duration !== null) {
+                        jsPsych.pluginAPI.setTimeout(function() {
+                            display_element.querySelector('#jspsych-image-audio-response-stimulus').style.visibility = 'hidden';
+                        }, trial.stimulus_duration);
+                    }
+                    if (!trial.wait_for_mic_approval) {
+                        start_recording();
+                    }
+                }
+
+                // audio element processing
+                function start_recording() {
+                    // hide existing playback elements
+                    playbackElements.forEach(function (id) {
+                        let element = document.getElementById(id);
+                        element.style.visibility = 'hidden';
+                    });
+                    navigator.mediaDevices.getUserMedia({ audio: true, video: false }).then(process_audio);
+                    if (!trial.wait_for_mic_approval) {
+                        // Add visual indicators to let people know we're recording
+                        document.querySelector('#jspsych-image-audio-response-recording-container').innerHTML = trial.recording_on_indicator;
+                    }
+                }
+                
+                // function to handle responses by the subject
+                function process_audio(stream) {
+
+                    if (trial.wait_for_mic_approval) {
+                        if (start_time === null) {
+                            start_trial();
+                        } else {
+                            document.querySelector('#jspsych-image-audio-response-recording-container').innerHTML = trial.recording_on_indicator;
+                        }
+                    } 
+
+                    // This code largely thanks to skyllo at
+                    // http://air.ghost.io/recording-to-an-audio-file-using-html5-and-js/
+
+                    // store streaming data chunks in array
+                    const chunks = [];
+                    // create media recorder instance to initialize recording
+                    // Note: the MediaRecorder function is not supported in Safari or Edge
+                    recorder = new MediaRecorder(stream);
+                    recorder.data = [];
+                    recorder.wrapUp = false;
+                    recorder.ondataavailable = function(e) {
+                        // add stream data to chunks
+                        chunks.push(e.data);
+                        if (recorder.wrapUp) {
+                            if (typeof trial.postprocessing !== 'undefined') {
+                                trial.postprocessing(chunks)
+                                    .then(function(processedData) {
+                                        onRecordingFinish(processedData);
+                                    });
+                            } else {
+                                // should never fire - trial.postprocessing should use the default function if
+                                // not passed in via trial parameters
+                                onRecordingFinish(chunks);
+                            }
+                        }
+                    };
+
+                    // start recording with 1 second time between receiving 'ondataavailable' events
+                    recorder.start(1000);
+                    // setTimeout to stop recording after 4 seconds
+                    setTimeout(function() {
+                        // this will trigger one final 'ondataavailable' event and set recorder state to 'inactive'
+                        recorder.stop();
+                        recorder.wrapUp = true;
+                    }, trial.buffer_length);
+                }
+
+                function showPlaybackTools(data) {
+                    // Audio Player
+                    let playerDiv = display_element.querySelector('#jspsych-image-audio-response-audio-container');
+                    let url;
+                    if (data instanceof Blob) {
+                        const blob = new Blob(data, { type: 'audio/webm' });
+                        url = (URL.createObjectURL(blob));
+                    } else {
+                        url = data;
+                    }
+                    let player = playerDiv.querySelector('#jspsych-image-audio-response-audio');
+                    player.src = url;
+                    player.style.visibility = "visible";
+                    // Okay/rerecord buttons
+                    let buttonDiv = document.querySelector('#jspsych-image-audio-response-buttons');
+                    let okay = buttonDiv.querySelector('#jspsych-image-audio-response-okay');
+                    let rerecord = buttonDiv.querySelector('#jspsych-image-audio-response-rerecord');
+                    okay.style.visibility = 'visible';
+                    rerecord.style.visibility = 'visible';
+                    // Save ids of things we want to hide later:
+                    playbackElements = [player.id, okay.id, rerecord.id];
+                }
+
+                function onRecordingFinish(data) {
+                    // switch to the off visual indicator
+                    let light = document.querySelector('#jspsych-image-audio-response-recording-container');
+                    if (light !== null)
+                        light.innerHTML = trial.recording_off_indicator;
+                    // measure rt
+                    let end_time = performance.now();
+                    let rt = end_time - start_time;
+                    response.audio_data = data.str;
+                    response.audio_url = data.url;
+                    response.rt = rt;
+
+                    if (trial.response_ends_trial) {
+                        end_trial();
+                    } else if (trial.allow_playback) {  // only allow playback if response doesn't end trial
+                        showPlaybackTools(response.audio_url);
+                    } else { 
+                        // fallback in case response_ends_trial and allow_playback are both false, 
+                        // which would mean the trial never ends
+                        end_trial();
+                    }
+                }
+
+                if (trial.wait_for_mic_approval) {
+                    start_recording();
+                } else {
+                    start_trial();
+                }
             }
-            let player = playerDiv.querySelector('#jspsych-image-audio-response-audio');
-            player.src = url;
-            player.style.visibility = "visible";
-            // Okay/rerecord buttons
-            let buttonDiv = document.querySelector('#jspsych-image-audio-response-buttons');
-            let okay = buttonDiv.querySelector('#jspsych-image-audio-response-okay');
-            let rerecord = buttonDiv.querySelector('#jspsych-image-audio-response-rerecord');
-            okay.style.visibility = 'visible';
-            rerecord.style.visibility = 'visible';
-            // Save ids of things we want to hide later:
-            playbackElements = [player.id, okay.id, rerecord.id];
-        }
-
-        function onRecordingFinish(data) {
-            // switch to the off visual indicator
-            let light = document.querySelector('#jspsych-image-audio-response-recording-container');
-            if (light !== null)
-                light.innerHTML = trial.recording_off_indicator;
-            // measure rt
-            let end_time = performance.now();
-            let rt = end_time - start_time;
-            response.audio_data = data.str;
-            response.audio_url = data.url;
-            response.rt = rt;
-
-            if (trial.response_ends_trial) {
-                end_trial();
-            } else if (trial.allow_playback) {  // only allow playback if response doesn't end trial
-                showPlaybackTools(response.audio_url);
-            } else { 
-                // fallback in case response_ends_trial and allow_playback are both false, 
-                // which would mean the trial never ends
-                end_trial();
-            }
-        }
+        });
 
         // function to end trial when it is time
         function end_trial() {
@@ -371,7 +421,8 @@ jsPsych.plugins["image-audio-response"] = (function() {
             let trial_data = {
                 "rt": response.rt,
                 "stimulus": trial.stimulus,
-                "audio_data": response.audio_data
+                "audio_data": response.audio_data,
+                "has_mic": mic
             };
 
             // clear the display
@@ -379,12 +430,6 @@ jsPsych.plugins["image-audio-response"] = (function() {
 
             // move on to the next trial
             jsPsych.finishTrial(trial_data);
-        }
-
-        if (trial.wait_for_mic_approval) {
-            start_recording();
-        } else {
-            start_trial();
         }
 
     };

--- a/plugins/jspsych-image-audio-response.js
+++ b/plugins/jspsych-image-audio-response.js
@@ -78,23 +78,27 @@ jsPsych.plugins["image-audio-response"] = (function() {
                 description: 'Whether to allow the participant to play back their '+
                 'recording and re-record if unhappy.'
             },
-            recording_light: {
+			recording_indicator: {
+				type: jsPsych.plugins.parameterType.INT,
+				pretty_name: 'Recording indicator type',
+				default: 1,
+				description: 'Selects which recording indicator type to use. '+
+				'1- Obvious recording indicator (default). '+
+				'2- Unobtrusive recording indicator. '+
+				'3- Custom HTML. Stimulus will be placed directly above the HTML. '+
+				'4- Custom HTML. Stimulus will centred regardless of HTML positioning. '
+			},
+            recording_on_indicator: {
                 type: jsPsych.plugins.parameterType.HTML_STRING,
-                pretty_name: 'Recording light',
-                default: '<div id="jspsych-image-audio-response-light" '+
-                    'style="border: 2px solid darkred; background-color: darkred; '+
-                    'width: 50px; height: 50px; border-radius: 50px; margin: 20px auto; '+
-                    'display: block;"></div>',
-                description: 'HTML to display while recording is in progress.'
+                pretty_name: 'Recording indicator (on state)',
+				default: null, // default behaviour specified line 201
+				description: 'HTML to display while recording is in progress.'
             },
-            recording_light_off: {
+            recording_off_indicator: {
                 type: jsPsych.plugins.parameterType.HTML_STRING,
-                pretty_name: 'Recording light (off state)',
-                default: '<div id="jspsych-image-audio-response-light" '+
-                'style="border: 2px solid darkred; background-color: inherit; '+
-                'width: 50px; height: 50px; border-radius: 50px; margin: 20px auto; '+
-                'display: block;"></div>',
-                description: 'HTML to display while recording is not in progress.'
+                pretty_name: 'Recording indicator (off state)',
+					default: null, // default behaviour specified line 201
+				description: 'HTML to display while recording is not in progress.'
             },
             prompt: {
                 type: jsPsych.plugins.parameterType.STRING,
@@ -169,9 +173,18 @@ jsPsych.plugins["image-audio-response"] = (function() {
         let start_time = null;
 
         // add stimulus
-		var html = '<img src="'+trial.stimulus+'" id="jspsych-image-audio-response-stimulus" style="';
+		var html = '<img src="'+trial.stimulus+'" id="jspsych-image-audio-response-stimulus"';
+		if (trial.recording_indicator === 1 || trial.recording_indicator === 3) {
+			// if recording indicator is type 1 or 3 , then do nothing
+			// stimulus will stack on audio recording containers
+			html += 'style="';
+		} else {
+			// else dynamically position stimulus in centre of screen
+			// stimulus will be positioned out of flow
+			html += 'style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);';
+		}
 		if(trial.stimulus_height !== null){
-		  html += 'height:'+trial.stimulus_height+'px; '
+		  html += 'height:'+trial.stimulus_height+'px;';
 		  if(trial.stimulus_width == null && trial.maintain_aspect_ratio){
 			html += 'width: auto; ';
 		  }
@@ -188,9 +201,33 @@ jsPsych.plugins["image-audio-response"] = (function() {
         if (trial.prompt !== null) {
             html += trial.prompt;
         }
+		
+		// set up recording indicator
+		if (trial.recording_indicator === 1) {
+			// if indicator type 1, do HTML for obvious indicator
+			trial.recording_on_indicator = '<div id="jspsych-image-audio-response-indicator" '+
+				'style="border: 2px solid darkred; background-color: darkred; '+
+				'width: 50px; height: 50px; border-radius: 50px; margin: 20px auto; '+
+				'display: block;"></div>';	
+			trial.recording_off_indicator = '<div id="jspsych-image-audio-response-indicator" '+
+				'style="border: 2px solid darkred; background-color: inherit; '+
+				'width: 50px; height: 50px; border-radius: 50px; margin: 20px auto; '+
+				'display: block;"></div>';	
+		} else if (trial.recording_indicator === 2) {
+			// if indicator type 2 do HTML for unobtrusive indicator
+			trial.recording_on_indicator = '<div id="jspsych-image-audio-response-indicator" '+
+				'style="position: fixed; bottom: 0; right: 0;">recording...</div>';	
+			trial.recording_off_indicator = '<div id="jspsych-image-audio-response-indicator" '+
+				'style="position: fixed; bottom: 0; right: 0;">not recording...</div>';	
+		} else {
+			// if any other indicator type && HTML left unspecified then throw error but continue
+			if (trial.recording_on_indicator === null || trial.recording_off_indicator === null) {
+				console.error('No recording indicator HTML specified.');
+			}	
+		} 
 
-        // add recording off light
-        html += '<div id="jspsych-image-audio-response-recording-container">'+trial.recording_light_off+'</div>';
+        // add recording off indicator into HTML
+        html += '<div id="jspsych-image-audio-response-recording-container">'+trial.recording_off_indicator+'</div>';
 
         // add audio element container with hidden audio element
         html += '<div id="jspsych-image-audio-response-audio-container"><audio id="jspsych-image-audio-response-audio" controls style="visibility:hidden;"></audio></div>';
@@ -203,7 +240,7 @@ jsPsych.plugins["image-audio-response"] = (function() {
             document.querySelector('#jspsych-image-audio-response-okay').addEventListener('click', end_trial);
             document.querySelector('#jspsych-image-audio-response-rerecord').addEventListener('click', start_recording);
             // Add visual indicators to let people know we're recording
-            document.querySelector('#jspsych-image-audio-response-recording-container').innerHTML = trial.recording_light;
+            document.querySelector('#jspsych-image-audio-response-recording-container').innerHTML = trial.recording_on_indicator;
             // trial start time
             start_time = performance.now();
             // set timer to hide image if stimulus duration is set
@@ -227,7 +264,7 @@ jsPsych.plugins["image-audio-response"] = (function() {
             navigator.mediaDevices.getUserMedia({ audio: true, video: false }).then(process_audio);
             if (!trial.wait_for_mic_approval) {
                 // Add visual indicators to let people know we're recording
-                document.querySelector('#jspsych-image-audio-response-recording-container').innerHTML = trial.recording_light;
+                document.querySelector('#jspsych-image-audio-response-recording-container').innerHTML = trial.recording_on_indicator;
             }
         }
         
@@ -238,7 +275,7 @@ jsPsych.plugins["image-audio-response"] = (function() {
                 if (start_time === null) {
                     start_trial();
                 } else {
-                    document.querySelector('#jspsych-image-audio-response-recording-container').innerHTML = trial.recording_light;
+                    document.querySelector('#jspsych-image-audio-response-recording-container').innerHTML = trial.recording_on_indicator;
                 }
             } 
 
@@ -306,7 +343,7 @@ jsPsych.plugins["image-audio-response"] = (function() {
             // switch to the off visual indicator
             let light = document.querySelector('#jspsych-image-audio-response-recording-container');
             if (light !== null)
-                light.innerHTML = trial.recording_light_off;
+                light.innerHTML = trial.recording_off_indicator;
             // measure rt
             let end_time = performance.now();
             let rt = end_time - start_time;


### PR DESCRIPTION
First pass at recording indicator options. See what you think.

4 Options:

1 - Obvious recording indicator (default) - this is yours.
2 - Unobtrusive - this is mine
3 - Custom HTML but stimulus positioned in flow, as yours is currently
4 - Custom HTML but stimulus centred out of flow, as mine is in the unobtrusive version


Notes:

I refactored `recording light` variants as `recording indicator` variants. Hope you don't mind/that change makes sense. I'm not really wedded to anything here if it bothers you.

3 and 4 are an answer to your suggestion to permit editing of the recording indicator message. I thought it might be better to just offer full HTML access rather than a bunch of options. My thinking: they can always copy either of 1 or 2 as a template.

I used the default behaviour handling for the indicator HTML from the RDK plugin (i.e. default: null - then defaults for 1 and 2 are added later). I don't know if that's best practice, but I wasn't going to dig around too long trying to figure it out unfortunately. Also, in the case of 1 and 2 it overrides any custom HTML they might enter accidentally which seems sensible.

Currently, if 3 or 4 and no custom HTML entered, it will throw a `console.error` but continue anyway, displaying no recording indicator. Shouldn't be hard replace that with a hard stop like `throw new Error("whatever")` or something if you think that would be preferable.

It occurs to me that you might want my comments re:`centre/ing` changed to `center/ing`.